### PR TITLE
Partly revert "Replace rake task puts with logger commands " (#1215)

### DIFF
--- a/lib/tasks/liveness.rake
+++ b/lib/tasks/liveness.rake
@@ -2,5 +2,5 @@
 
 desc('livenessProbe')
 task liveness: :environment do
-  Rails.logger.info('success')
+  puts 'success'
 end

--- a/lib/tasks/meetings.rake
+++ b/lib/tasks/meetings.rake
@@ -66,7 +66,7 @@ namespace :meetings do
           meeting.destroy!
           get_post_req(encode_bbb_uri('end', meeting_server.url, meeting_server.secret,
                                       meetingID: meeting.id, password: moderator_pw))
-          puts("Clearing Meeting id=#{meeting.id}")
+          warn("Clearing Meeting id=#{meeting.id}")
         rescue ApplicationRedisRecord::RecordNotDestroyed => e
           raise("ERROR: Could not destroy meeting id=#{meeting.id}: #{e}")
         rescue StandardError => e

--- a/lib/tasks/meetings.rake
+++ b/lib/tasks/meetings.rake
@@ -87,7 +87,7 @@ namespace :meetings do
   desc('Get meeting details running in BigBlueButton servers')
   task :info, [:meeting_id] => :environment do |_t, args|
     if args.meeting_id.nil?
-      puts('Error: Please input a meetingID!')
+      warn('Error: Please input a meetingID!')
       exit(1)
     end
     include ApiHelper

--- a/lib/tasks/meetings.rake
+++ b/lib/tasks/meetings.rake
@@ -120,6 +120,6 @@ namespace :meetings do
     puts("\t\tbbb-recording-description: #{metadata.xpath('.//bbb-recording-description').text}")
     puts("\t\tbbb-origin-tag: #{metadata.xpath('.//bbb-origin-tag').text}")
   rescue StandardError => e
-    puts("WARNING: Could not get info for meeting id=#{meeting.id}: #{e}")
+    warn("WARNING: Could not get info for meeting id=#{meeting.id}: #{e}")
   end
 end

--- a/lib/tasks/meetings.rake
+++ b/lib/tasks/meetings.rake
@@ -21,9 +21,9 @@ task :meetings, [:meeting_ids] => :environment do |_t, args|
       response = get_post_req(encode_bbb_uri('getMeetingInfo', meeting_server.url,
                                              meeting_server.secret, meetingID: meeting.id))
       meeting_id = response.xpath('/response/meetingID').text
-      Rails.logger.info("\nMeetingID: #{meeting_id}")
-      Rails.logger.info("\tServer ID: #{meeting_server.id}")
-      Rails.logger.info("\tServer Url: #{meeting_server.url}")
+      puts("\nMeetingID: #{meeting_id}")
+      puts("\tServer ID: #{meeting_server.id}")
+      puts("\tServer Url: #{meeting_server.url}")
     rescue BBBErrors::BBBError => e
       Rails.logger.error("\nFailed to get meeting id=#{meeting.id} status: #{e}")
     rescue StandardError => e
@@ -44,8 +44,8 @@ namespace :meetings do
   desc('End all/specific meetings running in BigBlueButton servers')
   task :end, [:meeting_ids] => :environment do |_t, args|
     $stdout.sync = true
-    Rails.logger.info('WARNING: You are trying to clear active meetings.')
-    Rails.logger.info('If you still wish to continue please enter `yes`')
+    puts('WARNING: You are trying to clear active meetings.')
+    puts('If you still wish to continue please enter `yes`')
     response = $stdin.gets.chomp.casecmp('yes').zero?
     if response
       args.with_defaults(meeting_ids: '')
@@ -57,7 +57,7 @@ namespace :meetings do
                  else
                    Meeting.all
                  end
-      Rails.logger.info('No meetings to clear') if meetings.empty?
+      STDERR.puts('No meetings to clear') if meetings.empty?
       pool = Concurrent::FixedThreadPool.new(Rails.configuration.x.poller_threads.to_i - 1, name: 'end-meeting')
       tasks = meetings.map do |meeting|
         Concurrent::Promises.future_on(pool) do
@@ -66,7 +66,7 @@ namespace :meetings do
           meeting.destroy!
           get_post_req(encode_bbb_uri('end', meeting_server.url, meeting_server.secret,
                                       meetingID: meeting.id, password: moderator_pw))
-          Rails.logger.info("Clearing Meeting id=#{meeting.id}")
+          puts("Clearing Meeting id=#{meeting.id}")
         rescue ApplicationRedisRecord::RecordNotDestroyed => e
           raise("ERROR: Could not destroy meeting id=#{meeting.id}: #{e}")
         rescue StandardError => e
@@ -81,45 +81,45 @@ namespace :meetings do
       pool.shutdown
       pool.wait_for_termination(5) || pool.kill
     end
-    Rails.logger.info('OK')
+    puts('OK')
   end
 
   desc('Get meeting details running in BigBlueButton servers')
   task :info, [:meeting_id] => :environment do |_t, args|
     if args.meeting_id.nil?
-      Rails.logger.error('Error: Please input a meetingID!')
+      puts('Error: Please input a meetingID!')
       exit(1)
     end
     include ApiHelper
 
     meeting_id = args.meeting_id
     meeting = Meeting.find(meeting_id)
-    Rails.logger.info('No meeting info to show') if meeting.nil?
+    puts('No meeting info to show') if meeting.nil?
     meeting_server = meeting.server
     response = get_post_req(encode_bbb_uri('getMeetingInfo', meeting_server.url,
                                            meeting_server.secret, meetingID: meeting.id))
-    Rails.logger.info("\nMeeting ID: #{response.xpath('/response/meetingID').text}")
-    Rails.logger.info("\tMeeting Name: #{response.xpath('/response/meetingName').text}")
-    Rails.logger.info("\tInternal MeetingID: #{response.xpath('/response/internalMeetingID').text}")
-    Rails.logger.info("\tCreated Date: #{response.xpath('/response/createDate').text}")
-    Rails.logger.info("\tRecording Enabled: #{response.xpath('/response/recording').text}")
-    Rails.logger.info("\tServer id: #{meeting_server.id}")
-    Rails.logger.info("\tSerevr url: #{meeting_server.url}")
+    puts("\nMeeting ID: #{response.xpath('/response/meetingID').text}")
+    puts("\tMeeting Name: #{response.xpath('/response/meetingName').text}")
+    puts("\tInternal MeetingID: #{response.xpath('/response/internalMeetingID').text}")
+    puts("\tCreated Date: #{response.xpath('/response/createDate').text}")
+    puts("\tRecording Enabled: #{response.xpath('/response/recording').text}")
+    puts("\tServer id: #{meeting_server.id}")
+    puts("\tSerevr url: #{meeting_server.url}")
     metadata = response.xpath('/response/metadata')
-    Rails.logger.info("\tMetaData:")
-    Rails.logger.info("\t\tbbb-context-name: #{metadata.xpath('.//bbb-context-name').text}")
-    Rails.logger.info("\t\tanalytics-callback-url: #{metadata.xpath('.//analytics-callback-url').text}")
-    Rails.logger.info("\t\tbbb-recording-tags: #{metadata.xpath('.//bbb-recording-tags').text}")
-    Rails.logger.info("\t\tbbb-origin-server-common-name: #{metadata.xpath('.//bbb-origin-server-common-name').text}")
-    Rails.logger.info("\t\tbbb-context-label: #{metadata.xpath('.//bbb-context-label').text}")
-    Rails.logger.info("\t\tbbb-origin: #{metadata.xpath('.//bbb-context-name').text}")
-    Rails.logger.info("\t\tbbb-context: #{metadata.xpath('.//bbb-context').text}")
-    Rails.logger.info("\t\tbbb-context-id: #{metadata.xpath('.//bbb-context-id').text}")
-    Rails.logger.info("\t\tbbb-recording-name: #{metadata.xpath('.//bbb-recording-name').text}")
-    Rails.logger.info("\t\tbbb-origin-server-name: #{metadata.xpath('.//bbb-origin-server-name').text}")
-    Rails.logger.info("\t\tbbb-recording-description: #{metadata.xpath('.//bbb-recording-description').text}")
-    Rails.logger.info("\t\tbbb-origin-tag: #{metadata.xpath('.//bbb-origin-tag').text}")
+    puts("\tMetaData:")
+    puts("\t\tbbb-context-name: #{metadata.xpath('.//bbb-context-name').text}")
+    puts("\t\tanalytics-callback-url: #{metadata.xpath('.//analytics-callback-url').text}")
+    puts("\t\tbbb-recording-tags: #{metadata.xpath('.//bbb-recording-tags').text}")
+    puts("\t\tbbb-origin-server-common-name: #{metadata.xpath('.//bbb-origin-server-common-name').text}")
+    puts("\t\tbbb-context-label: #{metadata.xpath('.//bbb-context-label').text}")
+    puts("\t\tbbb-origin: #{metadata.xpath('.//bbb-context-name').text}")
+    puts("\t\tbbb-context: #{metadata.xpath('.//bbb-context').text}")
+    puts("\t\tbbb-context-id: #{metadata.xpath('.//bbb-context-id').text}")
+    puts("\t\tbbb-recording-name: #{metadata.xpath('.//bbb-recording-name').text}")
+    puts("\t\tbbb-origin-server-name: #{metadata.xpath('.//bbb-origin-server-name').text}")
+    puts("\t\tbbb-recording-description: #{metadata.xpath('.//bbb-recording-description').text}")
+    puts("\t\tbbb-origin-tag: #{metadata.xpath('.//bbb-origin-tag').text}")
   rescue StandardError => e
-    Rails.logger.error("WARNING: Could not get info for meeting id=#{meeting.id}: #{e}")
+    puts("WARNING: Could not get info for meeting id=#{meeting.id}: #{e}")
   end
 end

--- a/lib/tasks/meetings.rake
+++ b/lib/tasks/meetings.rake
@@ -57,7 +57,7 @@ namespace :meetings do
                  else
                    Meeting.all
                  end
-      STDERR.puts('No meetings to clear') if meetings.empty?
+      warn('No meetings to clear') if meetings.empty?
       pool = Concurrent::FixedThreadPool.new(Rails.configuration.x.poller_threads.to_i - 1, name: 'end-meeting')
       tasks = meetings.map do |meeting|
         Concurrent::Promises.future_on(pool) do

--- a/lib/tasks/meetings.rake
+++ b/lib/tasks/meetings.rake
@@ -94,7 +94,7 @@ namespace :meetings do
 
     meeting_id = args.meeting_id
     meeting = Meeting.find(meeting_id)
-    puts('No meeting info to show') if meeting.nil?
+    warn('No meeting info to show') if meeting.nil?
     meeting_server = meeting.server
     response = get_post_req(encode_bbb_uri('getMeetingInfo', meeting_server.url,
                                            meeting_server.secret, meetingID: meeting.id))

--- a/lib/tasks/recordings.rake
+++ b/lib/tasks/recordings.rake
@@ -58,7 +58,7 @@ namespace :recordings do
       begin
         Metadatum.create!(recording_id: rec.id, key: 'tenant-id', value: tenant_id)
       rescue ActiveRecord::RecordInvalid => e
-        puts("Error creating metadatum record for recording with id #{rec.id}: #{e}")
+        warn("Error creating metadatum record for recording with id #{rec.id}: #{e}")
       end
     end
 

--- a/lib/tasks/recordings.rake
+++ b/lib/tasks/recordings.rake
@@ -49,7 +49,7 @@ namespace :recordings do
   task :addToTenant, [:tenant_id] => :environment do |_t, args|
     tenant_id = args[:tenant_id]
     unless tenant_id
-      STDERR.puts('No tenant ID was provided')
+      warn('No tenant ID was provided')
       exit(1)
     end
 

--- a/lib/tasks/recordings.rake
+++ b/lib/tasks/recordings.rake
@@ -49,7 +49,7 @@ namespace :recordings do
   task :addToTenant, [:tenant_id] => :environment do |_t, args|
     tenant_id = args[:tenant_id]
     unless tenant_id
-      Rails.logger.error('No tenant ID was provided')
+      STDERR.puts('No tenant ID was provided')
       exit(1)
     end
 
@@ -58,10 +58,10 @@ namespace :recordings do
       begin
         Metadatum.create!(recording_id: rec.id, key: 'tenant-id', value: tenant_id)
       rescue ActiveRecord::RecordInvalid => e
-        Rails.logger.error("Error creating metadatum record for recording with id #{rec.id}: #{e}")
+        puts("Error creating metadatum record for recording with id #{rec.id}: #{e}")
       end
     end
 
-    Rails.logger.info("All existing recordings have been successfully linked to tenant #{tenant_id}")
+    puts("All existing recordings have been successfully linked to tenant #{tenant_id}")
   end
 end

--- a/lib/tasks/servers.rake
+++ b/lib/tasks/servers.rake
@@ -3,7 +3,7 @@
 desc('List configured BigBlueButton servers')
 task servers: :environment do
   servers = Server.all
-  STDERR.puts('No servers are configured') if servers.empty?
+  warn('No servers are configured') if servers.empty?
   servers.each do |server|
     puts("id: #{server.id}")
     puts("\turl: #{server.url}")
@@ -25,12 +25,12 @@ namespace :servers do
   desc 'Add a new BigBlueButton server (it will be added disabled)'
   task :add, [:url, :secret, :load_multiplier, :tag] => :environment do |_t, args|
     if args.url.nil? || args.secret.nil?
-      STDERR.puts('Error: Please input at least a URL and a secret!')
+      warn('Error: Please input at least a URL and a secret!')
       exit(1)
     end
 
     unless args.url.start_with?('http://', 'https://')
-      STDERR.puts('Error: Server URL must start with http:// or https://')
+      warn('Error: Server URL must start with http:// or https://')
       exit(1)
     end
 
@@ -67,7 +67,7 @@ namespace :servers do
     server.save!
     puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound
-    STDERR.puts("ERROR: No server found with id: #{args.id}")
+    warn("ERROR: No server found with id: #{args.id}")
     exit(1)
   end
 
@@ -78,7 +78,7 @@ namespace :servers do
     server.destroy!
     puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound
-    STDERR.puts("ERROR: No server found with id: #{args.id}")
+    warn("ERROR: No server found with id: #{args.id}")
     exit(1)
   end
 
@@ -90,7 +90,7 @@ namespace :servers do
     server.save!
     puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound
-    STDERR.puts("ERROR: No server found with id: #{args.id}")
+    warn("ERROR: No server found with id: #{args.id}")
     exit(1)
   end
 
@@ -103,10 +103,10 @@ namespace :servers do
     server.save!
     puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound
-    STDERR.puts("ERROR: No server found with id: #{args.id}")
+    warn("ERROR: No server found with id: #{args.id}")
     exit(1)
   rescue StandardError => e
-    STDERR.puts("ERROR: Failed to cordon server #{args.id} - #{e}")
+    warn("ERROR: Failed to cordon server #{args.id} - #{e}")
     exit(1)
   end
 
@@ -117,7 +117,7 @@ namespace :servers do
     server = Server.find(args.id)
     response = true
     if server.load.to_f > 0.0
-      STDERR.puts("WARNING: You are trying to disable a server with active load. You should use the cordon option if
+      warn("WARNING: You are trying to disable a server with active load. You should use the cordon option if
           you do not want to clear all the meetings")
       puts('If you still wish to continue please enter `yes`')
       response = $stdin.gets.chomp.casecmp('yes').zero?
@@ -131,7 +131,7 @@ namespace :servers do
         rescue ApplicationRedisRecord::RecordNotDestroyed => e
           raise("ERROR: Could not destroy meeting id=#{meeting.id}: #{e}")
         rescue StandardError => e
-          STDERR.puts("WARNING: Could not end meeting id=#{meeting.id}: #{e}")
+          warn("WARNING: Could not end meeting id=#{meeting.id}: #{e}")
         end
       end
     end
@@ -139,7 +139,7 @@ namespace :servers do
     server.save!
     puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound
-    STDERR.puts("ERROR: No server found with id: #{args.id}")
+    warn("ERROR: No server found with id: #{args.id}")
     exit(1)
   end
 
@@ -160,16 +160,16 @@ namespace :servers do
     rescue ApplicationRedisRecord::RecordNotDestroyed => e
       raise("ERROR: Could not destroy meeting id=#{meeting.id}: #{e}")
     rescue StandardError => e
-      STDERR.puts("WARNING: Could not end meeting id=#{meeting.id}: #{e}")
+      warn("WARNING: Could not end meeting id=#{meeting.id}: #{e}")
     end
     server.state = 'disabled' unless args.keep_state
     server.save!
     puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound
-    STDERR.puts("ERROR: No server found with id: #{args.id}")
+    warn("ERROR: No server found with id: #{args.id}")
     exit(1)
   rescue StandardError => e
-    STDERR.puts("ERROR: Failed to panic server #{args.id} - #{e}")
+    warn("ERROR: Failed to panic server #{args.id} - #{e}")
     exit(1)
   end
 
@@ -188,7 +188,7 @@ namespace :servers do
     server.save!
     puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound
-    STDERR.puts("ERROR: No server found with id: #{args.id}")
+    warn("ERROR: No server found with id: #{args.id}")
     exit(1)
   end
 
@@ -199,7 +199,7 @@ namespace :servers do
     server.save!
     puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound
-    STDERR.puts("ERROR: No server found with id: #{args.id}")
+    warn("ERROR: No server found with id: #{args.id}")
     exit(1)
   end
 
@@ -212,7 +212,7 @@ namespace :servers do
       puts("id: #{created.id}")
     end
   rescue StandardError => e
-    STDERR.puts(e)
+    warn(e)
   end
 
   desc 'Sync cluster state with servers defined in a YAML file'
@@ -222,7 +222,7 @@ namespace :servers do
 
     ServerSync.sync_file(args.path, args.mode, args.dryrun)
   rescue StandardError => e
-    STDERR.puts("ERROR: #{e}")
+    warn("ERROR: #{e}")
     exit(1)
   end
 
@@ -251,11 +251,11 @@ namespace :servers do
         meetings = resp.xpath('/response/meetings/meeting')
         meeting_ids = meetings.map { |meeting| meeting.xpath('.//meetingName').text }
         puts("MeetingIDs: \n\t#{meeting_ids.join("\n\t")}")
-        STDERR.puts("\tNo meetings to display") if meeting_ids.empty?
+        warn("\tNo meetings to display") if meeting_ids.empty?
       rescue BBBErrors::BBBError => e
-        STDERR.puts("\nFailed to get server id=#{server.id} status: #{e}")
+        warn("\nFailed to get server id=#{server.id} status: #{e}")
       rescue StandardError => e
-        STDERR.puts("\nFailed to get meetings list status: #{e}")
+        warn("\nFailed to get meetings list status: #{e}")
       end
     end
     begin

--- a/lib/tasks/servers.rake
+++ b/lib/tasks/servers.rake
@@ -117,7 +117,7 @@ namespace :servers do
     server = Server.find(args.id)
     response = true
     if server.load.to_f > 0.0
-      warn("WARNING: You are trying to disable a server with active load. You should use the cordon option if
+      puts("WARNING: You are trying to disable a server with active load. You should use the cordon option if
           you do not want to clear all the meetings")
       puts('If you still wish to continue please enter `yes`')
       response = $stdin.gets.chomp.casecmp('yes').zero?

--- a/lib/tasks/servers.rake
+++ b/lib/tasks/servers.rake
@@ -213,6 +213,7 @@ namespace :servers do
     end
   rescue StandardError => e
     warn(e)
+    # Should there be an exit(1) here?
   end
 
   desc 'Sync cluster state with servers defined in a YAML file'

--- a/lib/tasks/servers.rake
+++ b/lib/tasks/servers.rake
@@ -3,21 +3,21 @@
 desc('List configured BigBlueButton servers')
 task servers: :environment do
   servers = Server.all
-  Rails.logger.info('No servers are configured') if servers.empty?
+  STDERR.puts('No servers are configured') if servers.empty?
   servers.each do |server|
-    Rails.logger.info("id: #{server.id}")
-    Rails.logger.info("\turl: #{server.url}")
-    Rails.logger.info("\tsecret: #{server.secret}")
+    puts("id: #{server.id}")
+    puts("\turl: #{server.url}")
+    puts("\tsecret: #{server.secret}")
     if server.state.present?
-      Rails.logger.info("\t#{server.state}")
+      puts("\t#{server.state}")
     else
-      Rails.logger.info("\t#{server.enabled ? 'enabled' : 'disabled'}")
+      puts("\t#{server.enabled ? 'enabled' : 'disabled'}")
     end
-    Rails.logger.info("\tload: #{server.load.presence || 'unavailable'}")
-    Rails.logger.info("\tload multiplier: #{server.load_multiplier.nil? ? 1.0 : server.load_multiplier.to_d}")
-    Rails.logger.info("\tbbb version: #{server.bbb_version.nil? ? '' : server.bbb_version}")
-    Rails.logger.info("\ttag: #{server.tag.nil? ? '' : server.tag}")
-    Rails.logger.info("\t#{server.online ? 'online' : 'offline'}")
+    puts("\tload: #{server.load.presence || 'unavailable'}")
+    puts("\tload multiplier: #{server.load_multiplier.nil? ? 1.0 : server.load_multiplier.to_d}")
+    puts("\tbbb version: #{server.bbb_version.nil? ? '' : server.bbb_version}")
+    puts("\ttag: #{server.tag.nil? ? '' : server.tag}")
+    puts("\t#{server.online ? 'online' : 'offline'}")
   end
 end
 
@@ -25,12 +25,12 @@ namespace :servers do
   desc 'Add a new BigBlueButton server (it will be added disabled)'
   task :add, [:url, :secret, :load_multiplier, :tag] => :environment do |_t, args|
     if args.url.nil? || args.secret.nil?
-      Rails.logger.error('Error: Please input at least a URL and a secret!')
+      STDERR.puts('Error: Please input at least a URL and a secret!')
       exit(1)
     end
 
     unless args.url.start_with?('http://', 'https://')
-      Rails.logger.error('Error: Server URL must start with http:// or https://')
+      STDERR.puts('Error: Server URL must start with http:// or https://')
       exit(1)
     end
 
@@ -45,8 +45,8 @@ namespace :servers do
       end
     end
     server = Server.create!(url: args.url, secret: args.secret, load_multiplier: tmp_load_multiplier, tag: args.tag.presence)
-    Rails.logger.info('OK')
-    Rails.logger.info("id: #{server.id}")
+    puts('OK')
+    puts("id: #{server.id}")
   end
 
   desc 'Update a BigBlueButton server'
@@ -65,9 +65,9 @@ namespace :servers do
     server.load_multiplier = tmp_load_multiplier
     server.tag = args.tag.presence unless args.tag.nil?
     server.save!
-    Rails.logger.info('OK')
+    puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound
-    Rails.logger.error("ERROR: No server found with id: #{args.id}")
+    STDERR.puts("ERROR: No server found with id: #{args.id}")
     exit(1)
   end
 
@@ -76,9 +76,9 @@ namespace :servers do
     Rails.logger.info("Removing server #{args.id}...")
     server = Server.find(args.id)
     server.destroy!
-    Rails.logger.info('OK')
+    puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound
-    Rails.logger.error("ERROR: No server found with id: #{args.id}")
+    STDERR.puts("ERROR: No server found with id: #{args.id}")
     exit(1)
   end
 
@@ -88,9 +88,9 @@ namespace :servers do
     server = Server.find(args.id)
     server.state = 'enabled'
     server.save!
-    Rails.logger.info('OK')
+    puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound
-    Rails.logger.error("ERROR: No server found with id: #{args.id}")
+    STDERR.puts("ERROR: No server found with id: #{args.id}")
     exit(1)
   end
 
@@ -101,12 +101,12 @@ namespace :servers do
     server = Server.find(args.id)
     server.state = 'cordoned'
     server.save!
-    Rails.logger.info('OK')
+    puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound
-    Rails.logger.error("ERROR: No server found with id: #{args.id}")
+    STDERR.puts("ERROR: No server found with id: #{args.id}")
     exit(1)
   rescue StandardError => e
-    Rails.logger.error("ERROR: Failed to cordon server #{args.id} - #{e}")
+    STDERR.puts("ERROR: Failed to cordon server #{args.id} - #{e}")
     exit(1)
   end
 
@@ -117,9 +117,9 @@ namespace :servers do
     server = Server.find(args.id)
     response = true
     if server.load.to_f > 0.0
-      Rails.logger.info("WARNING: You are trying to disable a server with active load. You should use the cordon option if
+      STDERR.puts("WARNING: You are trying to disable a server with active load. You should use the cordon option if
           you do not want to clear all the meetings")
-      Rails.logger.info('If you still wish to continue please enter `yes`')
+      puts('If you still wish to continue please enter `yes`')
       response = $stdin.gets.chomp.casecmp('yes').zero?
       if response
         meetings = Meeting.all.select { |m| m.server_id == server.id }
@@ -131,15 +131,15 @@ namespace :servers do
         rescue ApplicationRedisRecord::RecordNotDestroyed => e
           raise("ERROR: Could not destroy meeting id=#{meeting.id}: #{e}")
         rescue StandardError => e
-          Rails.logger.error("WARNING: Could not end meeting id=#{meeting.id}: #{e}")
+          STDERR.puts("WARNING: Could not end meeting id=#{meeting.id}: #{e}")
         end
       end
     end
     server.state = 'disabled' if response
     server.save!
-    Rails.logger.info('OK')
+    puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound
-    Rails.logger.error("ERROR: No server found with id: #{args.id}")
+    STDERR.puts("ERROR: No server found with id: #{args.id}")
     exit(1)
   end
 
@@ -160,16 +160,16 @@ namespace :servers do
     rescue ApplicationRedisRecord::RecordNotDestroyed => e
       raise("ERROR: Could not destroy meeting id=#{meeting.id}: #{e}")
     rescue StandardError => e
-      Rails.logger.error("WARNING: Could not end meeting id=#{meeting.id}: #{e}")
+      STDERR.puts("WARNING: Could not end meeting id=#{meeting.id}: #{e}")
     end
     server.state = 'disabled' unless args.keep_state
     server.save!
-    Rails.logger.info('OK')
+    puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound
-    Rails.logger.error("ERROR: No server found with id: #{args.id}")
+    STDERR.puts("ERROR: No server found with id: #{args.id}")
     exit(1)
   rescue StandardError => e
-    Rails.logger.error("ERROR: Failed to panic server #{args.id} - #{e}")
+    STDERR.puts("ERROR: Failed to panic server #{args.id} - #{e}")
     exit(1)
   end
 
@@ -186,9 +186,9 @@ namespace :servers do
     end
     server.load_multiplier = tmp_load_multiplier
     server.save!
-    Rails.logger.info('OK')
+    puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound
-    Rails.logger.error("ERROR: No server found with id: #{args.id}")
+    STDERR.puts("ERROR: No server found with id: #{args.id}")
     exit(1)
   end
 
@@ -197,9 +197,9 @@ namespace :servers do
     server = Server.find(args.id)
     server.tag = args.tag.presence
     server.save!
-    Rails.logger.info('OK')
+    puts('OK')
   rescue ApplicationRedisRecord::RecordNotFound
-    Rails.logger.error("ERROR: No server found with id: #{args.id}")
+    STDERR.puts("ERROR: No server found with id: #{args.id}")
     exit(1)
   end
 
@@ -208,11 +208,11 @@ namespace :servers do
     servers = YAML.load_file(args.path)['servers']
     servers.each do |server|
       created = Server.create!(url: server['url'], secret: server['secret'])
-      Rails.logger.info("server: #{created.url}")
-      Rails.logger.info("id: #{created.id}")
+      puts("server: #{created.url}")
+      puts("id: #{created.id}")
     end
   rescue StandardError => e
-    Rails.logger.error(e)
+    STDERR.puts(e)
   end
 
   desc 'Sync cluster state with servers defined in a YAML file'
@@ -222,13 +222,13 @@ namespace :servers do
 
     ServerSync.sync_file(args.path, args.mode, args.dryrun)
   rescue StandardError => e
-    Rails.logger.error("ERROR: #{e}")
+    STDERR.puts("ERROR: #{e}")
     exit(1)
   end
 
   desc 'Return a yaml compatible with servers:sync'
   task :yaml, [:verbose] => :environment do |_t, args|
-    Rails.logger.info({ 'servers' => ServerSync.dump(!!args.verbose) }.to_yaml)
+    puts({ "servers" => ServerSync.dump(!!args.verbose) }.to_yaml)
   end
 
   desc('List all meetings running in specific BigBlueButton servers')
@@ -245,17 +245,17 @@ namespace :servers do
     pool = Concurrent::FixedThreadPool.new(Rails.configuration.x.poller_threads.to_i - 1, name: 'sync-meeting-data')
     tasks = servers.map do |server|
       Concurrent::Promises.future_on(pool) do
-        Rails.logger.info("\nServer ID: #{server.id}")
-        Rails.logger.info("Server Url: #{server.url}")
+        puts("\nServer ID: #{server.id}")
+        puts("Server Url: #{server.url}")
         resp = get_post_req(encode_bbb_uri('getMeetings', server.url, server.secret))
         meetings = resp.xpath('/response/meetings/meeting')
         meeting_ids = meetings.map { |meeting| meeting.xpath('.//meetingName').text }
-        Rails.logger.info("MeetingIDs: \n\t#{meeting_ids.join("\n\t")}")
-        Rails.logger.info("\tNo meetings to display") if meeting_ids.empty?
+        puts("MeetingIDs: \n\t#{meeting_ids.join("\n\t")}")
+        STDERR.puts("\tNo meetings to display") if meeting_ids.empty?
       rescue BBBErrors::BBBError => e
-        Rails.logger.error("\nFailed to get server id=#{server.id} status: #{e}")
+        STDERR.puts("\nFailed to get server id=#{server.id} status: #{e}")
       rescue StandardError => e
-        Rails.logger.error("\nFailed to get meetings list status: #{e}")
+        STDERR.puts("\nFailed to get meetings list status: #{e}")
       end
     end
     begin

--- a/lib/tasks/servers.rake
+++ b/lib/tasks/servers.rake
@@ -228,7 +228,7 @@ namespace :servers do
 
   desc 'Return a yaml compatible with servers:sync'
   task :yaml, [:verbose] => :environment do |_t, args|
-    puts({ "servers" => ServerSync.dump(!!args.verbose) }.to_yaml)
+    puts({ 'servers' => ServerSync.dump(!!args.verbose) }.to_yaml)
   end
 
   desc('List all meetings running in specific BigBlueButton servers')

--- a/lib/tasks/status.rake
+++ b/lib/tasks/status.rake
@@ -37,7 +37,7 @@ server.largest_meeting, server.videos, server.load, server.bbb_version, server.t
     t.add_column('TAG', &:tag)
   end
 
-  Rails.logger.info("\n#{table.pack(max_table_width: nil)}")
+  puts "\n#{table.pack(max_table_width: nil)}"
 end
 
 def status_with_state(state)

--- a/lib/tasks/tenant_settings.rake
+++ b/lib/tasks/tenant_settings.rake
@@ -63,7 +63,7 @@ namespace :tenantSettings do
       Rails.logger.info('TenantSetting was successfully deleted.')
     else
       warn('Error! TenantSetting has not been deleted')
-      exit(1)
+      # Should there be an exit(1) here?
     end
   end
 end

--- a/lib/tasks/tenant_settings.rake
+++ b/lib/tasks/tenant_settings.rake
@@ -22,7 +22,7 @@ task tenantSettings: :environment do
         Rails.logger.info("\toverride: #{setting.override}")
       end
     else
-      STDERR.puts('  No custom settings are configured')
+      warn('  No custom settings are configured')
     end
   end
 end
@@ -37,7 +37,7 @@ namespace :tenantSettings do
     override = args[:override]
 
     unless tenant_id.present? && param.present? && value.present? && override.present?
-      STDERR.puts('Error: tenant_id, param, value and override are required to create a TenantSetting')
+      warn('Error: tenant_id, param, value and override are required to create a TenantSetting')
       exit(1)
     end
 
@@ -54,7 +54,7 @@ namespace :tenantSettings do
 
     setting = TenantSetting.find(id)
     if setting.blank?
-      STDERR.puts("TenantSetting with id #{id} does not exist in the system. Exiting...")
+      warn("TenantSetting with id #{id} does not exist in the system. Exiting...")
       exit(1)
     end
 
@@ -62,7 +62,7 @@ namespace :tenantSettings do
       puts("OK")
       Rails.logger.info('TenantSetting was successfully deleted.')
     else
-      STDERR.puts('Error! TenantSetting has not been deleted')
+      warn('Error! TenantSetting has not been deleted')
       exit(1)
     end
   end

--- a/lib/tasks/tenant_settings.rake
+++ b/lib/tasks/tenant_settings.rake
@@ -22,7 +22,7 @@ task tenantSettings: :environment do
         Rails.logger.info("\toverride: #{setting.override}")
       end
     else
-      Rails.logger.info('  No custom settings are configured')
+      STDERR.puts('  No custom settings are configured')
     end
   end
 end
@@ -37,14 +37,14 @@ namespace :tenantSettings do
     override = args[:override]
 
     unless tenant_id.present? && param.present? && value.present? && override.present?
-      Rails.logger.error('Error: tenant_id, param, value and override are required to create a TenantSetting')
+      STDERR.puts('Error: tenant_id, param, value and override are required to create a TenantSetting')
       exit(1)
     end
 
     setting = TenantSetting.create!(tenant_id: tenant_id, param: param, value: value, override: override)
 
-    Rails.logger.info('OK')
-    Rails.logger.info("New TenantSetting id: #{setting.id}")
+    puts('OK')
+    puts("New TenantSetting id: #{setting.id}")
   end
 
   desc 'Remove existing TenantSetting'
@@ -54,14 +54,16 @@ namespace :tenantSettings do
 
     setting = TenantSetting.find(id)
     if setting.blank?
-      Rails.logger.error("TenantSetting with id #{id} does not exist in the system. Exiting...")
+      STDERR.puts("TenantSetting with id #{id} does not exist in the system. Exiting...")
       exit(1)
     end
 
     if setting.destroy!
+      puts("OK")
       Rails.logger.info('TenantSetting was successfully deleted.')
     else
-      Rails.logger.error('Error! TenantSetting has not been deleted')
+      STDERR.puts('Error! TenantSetting has not been deleted')
+      exit(1)
     end
   end
 end

--- a/lib/tasks/tenant_settings.rake
+++ b/lib/tasks/tenant_settings.rake
@@ -59,7 +59,7 @@ namespace :tenantSettings do
     end
 
     if setting.destroy!
-      puts("OK")
+      # Should there be a puts("OK") here?
       Rails.logger.info('TenantSetting was successfully deleted.')
     else
       warn('Error! TenantSetting has not been deleted')

--- a/lib/tasks/tenant_settings.rake
+++ b/lib/tasks/tenant_settings.rake
@@ -60,7 +60,7 @@ namespace :tenantSettings do
 
     if setting.destroy!
       # Should there be a puts("OK") here?
-      Rails.logger.info('TenantSetting was successfully deleted.')
+      puts('TenantSetting was successfully deleted.')
     else
       warn('Error! TenantSetting has not been deleted')
       # Should there be an exit(1) here?

--- a/lib/tasks/tenants.rake
+++ b/lib/tasks/tenants.rake
@@ -11,21 +11,21 @@ task tenants: :environment do |_t, _args|
 
   if tenants.present?
     tenants.each do |tenant|
-      Rails.logger.info("id: #{tenant.id}")
-      Rails.logger.info("\tname: #{tenant.name}")
-      Rails.logger.info("\tsecrets: #{tenant.secrets}")
-      Rails.logger.info("\tlrs_endpoint: #{tenant.lrs_endpoint}") if tenant.lrs_endpoint.present?
-      Rails.logger.info("\tlrs_username: #{tenant.lrs_username}") if tenant.lrs_username.present?
-      Rails.logger.info("\tlrs_password: #{tenant.lrs_password}") if tenant.lrs_password.present?
-      Rails.logger.info("\tkc_token_url: #{tenant.kc_token_url}") if tenant.kc_token_url.present?
-      Rails.logger.info("\tkc_client_id: #{tenant.kc_client_id}") if tenant.kc_client_id.present?
-      Rails.logger.info("\tkc_client_secret: #{tenant.kc_client_secret}") if tenant.kc_client_secret.present?
-      Rails.logger.info("\tkc_username: #{tenant.kc_username}") if tenant.kc_username.present?
-      Rails.logger.info("\tkc_password: #{tenant.kc_password}") if tenant.kc_password.present?
+      puts("id: #{tenant.id}")
+      puts("\tname: #{tenant.name}")
+      puts("\tsecrets: #{tenant.secrets}")
+      puts("\tlrs_endpoint: #{tenant.lrs_endpoint}") if tenant.lrs_endpoint.present?
+      puts("\tlrs_username: #{tenant.lrs_username}") if tenant.lrs_username.present?
+      puts("\tlrs_password: #{tenant.lrs_password}") if tenant.lrs_password.present?
+      puts("\tkc_token_url: #{tenant.kc_token_url}") if tenant.kc_token_url.present?
+      puts("\tkc_client_id: #{tenant.kc_client_id}") if tenant.kc_client_id.present?
+      puts("\tkc_client_secret: #{tenant.kc_client_secret}") if tenant.kc_client_secret.present?
+      puts("\tkc_username: #{tenant.kc_username}") if tenant.kc_username.present?
+      puts("\tkc_password: #{tenant.kc_password}") if tenant.kc_password.present?
     end
   end
 
-  Rails.logger.info("Total number of tenants: #{tenants.size}")
+  puts "Total number of tenants: #{tenants.size}"
 end
 
 namespace :tenants do
@@ -36,14 +36,14 @@ namespace :tenants do
     secrets = args[:secrets]
 
     unless name.present? && secrets.present?
-      Rails.logger.error('Error: both name and secrets are required to create a Tenant')
+      STDERR.puts('Error: both name and secrets are required to create a Tenant')
       exit(1)
     end
 
     tenant = Tenant.create!(name: name, secrets: secrets)
 
-    Rails.logger.info('OK')
-    Rails.logger.info("New Tenant id: #{tenant.id}")
+    puts('OK')
+    puts("New Tenant id: #{tenant.id}")
   end
 
   desc 'Update an existing Tenant'
@@ -54,7 +54,7 @@ namespace :tenants do
     secrets = args[:secrets]
 
     if id.blank? || !(name.present? || secrets.present?)
-      Rails.logger.error('Error: id and either name or secrets are required to update a Tenant')
+      STDERR.puts('Error: id and either name or secrets are required to update a Tenant')
       exit(1)
     end
 
@@ -64,8 +64,8 @@ namespace :tenants do
 
     tenant.save!
 
-    Rails.logger.info('OK')
-    Rails.logger.info("Updated Tenant id: #{tenant.id}")
+    puts('OK')
+    puts("Updated Tenant id: #{tenant.id}")
   end
 
   desc 'Update an existing Tenants LRS credentials with basic authentication'
@@ -77,7 +77,7 @@ namespace :tenants do
     lrs_password = args[:lrs_password]
 
     if id.blank? || lrs_endpoint.blank? || lrs_username.blank? || lrs_password.blank?
-      Rails.logger.error('Error: id, LRS_ENDPOINT, LRS_USERNAME, LRS_PASSWORD are required to update a Tenant')
+      STDERR.puts('Error: id, LRS_ENDPOINT, LRS_USERNAME, LRS_PASSWORD are required to update a Tenant')
       exit(1)
     end
 
@@ -88,8 +88,8 @@ namespace :tenants do
 
     tenant.save!
 
-    Rails.logger.info('OK')
-    Rails.logger.info("Updated Tenant id: #{tenant.id}")
+    puts('OK')
+    puts("Updated Tenant id: #{tenant.id}")
   end
 
   desc 'Update an existing Tenants LRS credentials with Keycloak'
@@ -105,9 +105,7 @@ namespace :tenants do
 
     if id.blank? || lrs_endpoint.blank? || kc_token_url.blank? || kc_client_id.blank? ||
        kc_client_secret.blank? || kc_username.blank? || kc_password.blank?
-      Rails.logger.error(
-        'Error: LRS_ENDPOINT, KC_TOKEN_URL, KC_CLIENT_ID, KC_CLIENT_SECRET, KC_USERNAME, KC_PASSWORD are required to update a Tenant'
-      )
+      STDERR.puts('Error: LRS_ENDPOINT, KC_TOKEN_URL, KC_CLIENT_ID, KC_CLIENT_SECRET, KC_USERNAME, KC_PASSWORD are required to update a Tenant')
       exit(1)
     end
 
@@ -121,8 +119,8 @@ namespace :tenants do
 
     tenant.save!
 
-    Rails.logger.info('OK')
-    Rails.logger.info("Updated Tenant id: #{tenant.id}")
+    puts('OK')
+    puts("Updated Tenant id: #{tenant.id}")
   end
 
   desc 'Remove existing Tenant'
@@ -132,14 +130,16 @@ namespace :tenants do
 
     tenant = Tenant.find(id)
     if tenant.blank?
-      Rails.logger.error("Tenant with id #{id} does not exist in the system. Exiting...")
+      STDERR.puts("Tenant with id #{id} does not exist in the system. Exiting...")
       exit(1)
     end
 
     if tenant.destroy!
+      puts("OK")
       Rails.logger.info('Tenant was successfully deleted.')
     else
-      Rails.logger.error('Error! Tenant has not been deleted')
+      STDERR.puts('Error! Tenant has not been deleted')
+      exit(1)
     end
   end
 end

--- a/lib/tasks/tenants.rake
+++ b/lib/tasks/tenants.rake
@@ -135,11 +135,11 @@ namespace :tenants do
     end
 
     if tenant.destroy!
-      puts("OK")
+      # Should there be a puts("OK") here?
       Rails.logger.info('Tenant was successfully deleted.')
     else
       warn('Error! Tenant has not been deleted')
-      exit(1)
+      # Should there be an exit(1) here?
     end
   end
 end

--- a/lib/tasks/tenants.rake
+++ b/lib/tasks/tenants.rake
@@ -136,7 +136,7 @@ namespace :tenants do
 
     if tenant.destroy!
       # Should there be a puts("OK") here?
-      Rails.logger.info('Tenant was successfully deleted.')
+      puts('Tenant was successfully deleted.')
     else
       warn('Error! Tenant has not been deleted')
       # Should there be an exit(1) here?

--- a/lib/tasks/tenants.rake
+++ b/lib/tasks/tenants.rake
@@ -36,7 +36,7 @@ namespace :tenants do
     secrets = args[:secrets]
 
     unless name.present? && secrets.present?
-      STDERR.puts('Error: both name and secrets are required to create a Tenant')
+      warn('Error: both name and secrets are required to create a Tenant')
       exit(1)
     end
 
@@ -54,7 +54,7 @@ namespace :tenants do
     secrets = args[:secrets]
 
     if id.blank? || !(name.present? || secrets.present?)
-      STDERR.puts('Error: id and either name or secrets are required to update a Tenant')
+      warn('Error: id and either name or secrets are required to update a Tenant')
       exit(1)
     end
 
@@ -77,7 +77,7 @@ namespace :tenants do
     lrs_password = args[:lrs_password]
 
     if id.blank? || lrs_endpoint.blank? || lrs_username.blank? || lrs_password.blank?
-      STDERR.puts('Error: id, LRS_ENDPOINT, LRS_USERNAME, LRS_PASSWORD are required to update a Tenant')
+      warn('Error: id, LRS_ENDPOINT, LRS_USERNAME, LRS_PASSWORD are required to update a Tenant')
       exit(1)
     end
 
@@ -105,7 +105,7 @@ namespace :tenants do
 
     if id.blank? || lrs_endpoint.blank? || kc_token_url.blank? || kc_client_id.blank? ||
        kc_client_secret.blank? || kc_username.blank? || kc_password.blank?
-      STDERR.puts('Error: LRS_ENDPOINT, KC_TOKEN_URL, KC_CLIENT_ID, KC_CLIENT_SECRET, KC_USERNAME, KC_PASSWORD are required to update a Tenant')
+      warn('Error: LRS_ENDPOINT, KC_TOKEN_URL, KC_CLIENT_ID, KC_CLIENT_SECRET, KC_USERNAME, KC_PASSWORD are required to update a Tenant')
       exit(1)
     end
 
@@ -130,7 +130,7 @@ namespace :tenants do
 
     tenant = Tenant.find(id)
     if tenant.blank?
-      STDERR.puts("Tenant with id #{id} does not exist in the system. Exiting...")
+      warn("Tenant with id #{id} does not exist in the system. Exiting...")
       exit(1)
     end
 
@@ -138,7 +138,7 @@ namespace :tenants do
       puts("OK")
       Rails.logger.info('Tenant was successfully deleted.')
     else
-      STDERR.puts('Error! Tenant has not been deleted')
+      warn('Error! Tenant has not been deleted')
       exit(1)
     end
   end

--- a/spec/tasks/servers/servers_tasks_spec.rb
+++ b/spec/tasks/servers/servers_tasks_spec.rb
@@ -46,11 +46,9 @@ RSpec.describe 'servers tasks', type: :task do
       task.invoke(verbose)
     end
 
-    it 'logs yaml data' do
+    it 'outputs yaml data to stdout' do
       allow(ServerSync).to receive(:dump).with(verbose).and_return([{ url: 'https://example.com', secret: 'secret' }])
-      expect(Rails.logger).to receive(:info).with(include('url: https://example.com'))
-
-      task.invoke(verbose)
+      expect { task.invoke(verbose) }.to output(%r{url: https://example.com}).to_stdout
     end
   end
 end

--- a/spec/tasks/tenants_task_spec.rb
+++ b/spec/tasks/tenants_task_spec.rb
@@ -20,20 +20,15 @@ RSpec.describe 'tenants tasks', type: :task do
       tenant1 = create(:tenant)
       tenant2 = create(:tenant)
 
-      [tenant1, tenant2].each do |tenant|
-        expect(Rails.logger).to receive(:info).with("id: #{tenant.id}")
-        expect(Rails.logger).to receive(:info).with("\tname: #{tenant.name}")
-        expect(Rails.logger).to receive(:info).with("\tsecrets: #{tenant.secrets}")
-      end
-      expect(Rails.logger).to receive(:info).with('Total number of tenants: 2')
-
-      task.invoke
+      # rubocop:disable Layout/LineLength
+      expect { task.invoke }.to output(
+        "id: #{tenant2.id}\n\tname: #{tenant2.name}\n\tsecrets: #{tenant2.secrets}\nid: #{tenant1.id}\n\tname: #{tenant1.name}\n\tsecrets: #{tenant1.secrets}\nTotal number of tenants: 2\n"
+      ).to_stdout
+      # rubocop:enable Layout/LineLength
     end
 
     it 'displays a message if there are no tenants' do
-      expect(Rails.logger).to receive(:info).with('Total number of tenants: 0')
-
-      task.invoke
+      expect { task.invoke }.to output(/Total number of tenants: 0\n/).to_stdout
     end
   end
 


### PR DESCRIPTION
Output which is meant to be parsed or displayed interactively uses puts

Output which indicates an error for an interactive command uses STDERR.puts — and is usually followed by exit(1)

Other informative output about the progress of an operation uses Rails.logger.info, Rails.logger.error etc.

<!--- 
IMPORTANT
This template is mandatory for all Pull Requests.
Please follow the template to ensure your Pull Request is reviewed.
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Testing Steps
<!--- Please describe in detail how to test your changes. -->

## Screenshots (if appropriate):
<!--- Please include screenshots of ALL visual changes. -->
